### PR TITLE
Execute notebooks on each build

### DIFF
--- a/notebooks/_config.yml
+++ b/notebooks/_config.yml
@@ -7,9 +7,9 @@ logo: images/logos/pythia_logo-white-rtext.svg
 email: projectpythia@ucar.edu
 copyright: '2022'
 
-# Don't execute the notebooks upon building the book
+# Execute the notebooks upon building the book?
 execute:
-  execute_notebooks: "off"
+  execute_notebooks: "on"
 
 # Add a few extensions to help with parsing content
 parse:


### PR DESCRIPTION
I see now that our Template has `execute_notebooks: "off"` in the config file. I think we should change this to default to always executing, otherwise the testing isn't very useful.

This PR changes that setting for this cookbook.